### PR TITLE
ghdl: use DESTDIR instead of --prefix

### DIFF
--- a/scripts/compile_ghdl.sh
+++ b/scripts/compile_ghdl.sh
@@ -22,16 +22,17 @@ if [ $ARCH == "darwin" ]; then
     OLD_PATH=$PATH
     export PATH="$GNAT_ROOT/bin:$PATH"
 
-    ./configure --prefix=$PACKAGE_DIR/$NAME
-
+    ./configure --prefix=/opt/fpga-toolchain
     $MAKE -j$J GNAT_LARGS="-static-libgcc $ZLIB_ROOT/lib/libz.a"
-    $MAKE install
+    $MAKE DESTDIR=$PACKAGE_DIR/$NAME-prefix install
+    cp -r $PACKAGE_DIR/$NAME-prefix/opt/fpga-toolchain/* $PACKAGE_DIR/$NAME
 
     export PATH="$OLD_PATH"
 else
-    ./configure --prefix=$PACKAGE_DIR/$NAME
+    ./configure --prefix=/opt/fpga-toolchain
     $MAKE -j$J GNAT_BARGS="-bargs -E -static" GNAT_LARGS="-static -lz"
-    $MAKE install
+    $MAKE DESTDIR=$PACKAGE_DIR/$NAME-prefix install
+    cp -r $PACKAGE_DIR/$NAME-prefix/opt/fpga-toolchain/* $PACKAGE_DIR/$NAME
 fi
 
 test_bin $PACKAGE_DIR/$NAME/bin/ghdl$exe


### PR DESCRIPTION
Currently, `compile_ghdl.sh` uses `--prefix` for modifying the location where `make install` places the artifacts. However, configuring GHDL with a custom prefix has other effects. It is hardcoded in the tool, and it is later used for searching libs. As a result, it can produce errors with weird paths, such as https://github.com/umarcor/fomu-workshop/runs/1243053586?check_suite_focus=true#step:9:46.

In this PR, the prefix is not modified. Instead, `DESTDIR` is used for telling `make install` where to put the content.

Ref: https://github.com/ghdl/ghdl/blob/master/dist/ci-run.sh#L317