### PR TITLE
Clean up clean script by reusing code

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -57,6 +57,8 @@ CREATE_PACKAGE="${CREATE_PACKAGE:-1}"
 
 . scripts/_common.sh $1
 
+build_setup
+
 if [ $BUNDLE_PYTHON == "1" ]; then
   print ">> Bundle Python"
   . $WORK_DIR/scripts/bundle_python.sh

--- a/build_bba.sh
+++ b/build_bba.sh
@@ -14,6 +14,8 @@ INSTALL_DEPS="${INSTALL_DEPS:-1}"
 export VERSION=nightly
 . scripts/_common.sh linux_x86_64
 
+build_setup
+
 print ">> Compile nextpnr-ecp5-bba"
 . $WORK_DIR/scripts/compile_nextpnr_ecp5_bba.sh
 

--- a/clean.sh
+++ b/clean.sh
@@ -5,53 +5,12 @@
 
 set -e
 
-# -- Target architectures
-ARCH=$1
-TARGET_ARCHS="linux_x86_64 linux_i686 linux_armv7l linux_aarch64 windows_x86 windows_amd64 darwin"
-
-# -- Store current dir
-WORK_DIR=$PWD
-# -- Folder for building the source code
-BUILDS_DIR=$WORK_DIR/_builds
-# -- Folder for storing the generated packages
-PACKAGES_DIR=$WORK_DIR/_packages
-
-UPSTREAM_DIR=$WORK_DIR/_upstream
-
-# -- Check ARCH
-if [[ $# > 1 ]]; then
-  echo ""
-  echo "Error: too many arguments"
-  exit 1
-fi
-
-if [[ $# < 1 ]]; then
-  echo ""
-  echo "Usage: bash clean.sh TARGET"
-  echo ""
-  echo "Targets: $TARGET_ARCHS"
-  exit 1
-fi
-
-if [[ $ARCH =~ [[:space:]] || ! $TARGET_ARCHS =~ (^|[[:space:]])$ARCH([[:space:]]|$) ]]; then
-  echo ""
-  echo ">>> WRONG ARCHITECTURE \"$ARCH\""
-  exit 1
-fi
-
-echo ""
-echo ">>> ARCHITECTURE \"$ARCH\""
+. scripts/_common.sh $1
 
 printf "Are you sure? [y/N]: "
 read RESP
 case "$RESP" in
     [yY][eE][sS]|[yY])
-      # -- Directory for compiling the tools
-      BUILD_DIR=$BUILDS_DIR/build_$ARCH
-
-      # -- Directory for installation the target files
-      PACKAGE_DIR=$PACKAGES_DIR/build_$ARCH
-
       # -- Remove the package dir
       rm -r -f $PACKAGE_DIR
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -26,26 +26,11 @@ export PACKAGES_DIR=$WORK_DIR/_packages
 # --  Folder for storing the source code from github
 export UPSTREAM_DIR=$WORK_DIR/_upstream
 
-# -- Create the build directory
-mkdir -p $BUILDS_DIR
-# -- Create the packages directory
-mkdir -p $PACKAGES_DIR
-# -- Create the upstream directory and enter into it
-mkdir -p $UPSTREAM_DIR
-
 # -- Directory for compiling the tools
 export BUILD_DIR=$BUILDS_DIR/build_$ARCH
 
 # -- Directory for installation the target files
 export PACKAGE_DIR=$PACKAGES_DIR/build_$ARCH
-
-# -- Create the build dir
-mkdir -p $BUILD_DIR
-
-# -- Create the package folders
-mkdir -p $PACKAGE_DIR/$NAME/{bin,lib,share}
-mkdir -p $PACKAGE_DIR/${NAME}_symbols/{bin,lib}
-mkdir -p $PACKAGE_DIR/${NAME}-progtools/bin
 
 # -- Test script function
 function test_bin {
@@ -167,6 +152,32 @@ function wget_retry {
     done
 }
 
+# -- Initial setup for the build tree
+function build_setup {
+    # -- Create the build directory
+    mkdir -p $BUILDS_DIR
+    # -- Create the packages directory
+    mkdir -p $PACKAGES_DIR
+    # -- Create the upstream directory
+    mkdir -p $UPSTREAM_DIR
+
+    # -- Create the build dir
+    mkdir -p $BUILD_DIR
+
+    # -- Create the package folders
+    mkdir -p $PACKAGE_DIR/$NAME/{bin,lib,share}
+    mkdir -p $PACKAGE_DIR/${NAME}_symbols/{bin,lib}
+    mkdir -p $PACKAGE_DIR/${NAME}-progtools/bin
+
+    if [ $INSTALL_DEPS == "1" ]; then
+      print ">> Install dependencies"
+      . $WORK_DIR/scripts/install_dependencies.sh
+    fi
+
+    print ">> Set build flags"
+    . $WORK_DIR/scripts/build_setup.sh
+}
+
 # -- Check ARCH
 if [[ $# > 1 ]]; then
   echo ""
@@ -190,11 +201,3 @@ fi
 
 echo ""
 echo ">>> ARCHITECTURE \"$ARCH\""
-
-if [ $INSTALL_DEPS == "1" ]; then
-  print ">> Install dependencies"
-  . $WORK_DIR/scripts/install_dependencies.sh
-fi
-
-print ">> Set build flags"
-. $WORK_DIR/scripts/build_setup.sh

--- a/scripts/test/run_tests.sh
+++ b/scripts/test/run_tests.sh
@@ -17,6 +17,9 @@ TEST_NEXTPNR_PYTHON="${TEST_NEXTPNR_PYTHON:-1}"
 TEST_SBY="${TEST_SBY:-1}"
 
 . scripts/_common.sh $1
+
+build_setup
+
 . $WORK_DIR/scripts/test/install_toolchain.sh
 
 if [ $TEST_BINARIES_EXECUTE == "1" ]; then


### PR DESCRIPTION
The only user-visible change should be that this causes the list of targets to be the same between the build scripts and the clean script.

Internally the `_common.sh` script is reused to avoid duplicating logic. To achieve this, that script now defines only environment
variables and functions but does not do anything actively (to avoid creating the directories that should be removed in the first place). All the build initialization has been moved to a function `build_setup` to which calls are added where needed.