### PR TITLE
ghdl: ensure that version contains a valid string

### DIFF
--- a/scripts/compile_ghdl.sh
+++ b/scripts/compile_ghdl.sh
@@ -12,6 +12,10 @@ cd $BUILD_DIR/$dir_name
 
 # remove unwanted -lz linker flag on Darwin (because it causes a dynamic link)
 patch -p1 < $WORK_DIR/scripts/libghdl_static.diff
+patch -p1 < $WORK_DIR/scripts/ghdl_version.diff
+
+export GHDL_DESC="$(git -C $UPSTREAM_DIR/$dir_name describe --dirty 2> /dev/null)"
+sed -i -e "s/@BUILDER@/open-tool-forge.$VERSION/" src/version.in
 
 # -- Compile it
 if [ $ARCH == "darwin" ]; then

--- a/scripts/ghdl_version.diff
+++ b/scripts/ghdl_version.diff
@@ -1,0 +1,10 @@
+--- a/src/version.in
++++ b/src/version.in
+@@ -1,5 +1,6 @@
+ package Version is
+    Ghdl_Ver : constant String := "@VER@";
+    Ghdl_Release : constant String :=
+-      "(tarball) [Dunoon edition]";
++      "(tarball) [Dunoon edition]" &
++      " @BUILDER@";
+ end Version;


### PR DESCRIPTION
As commented in https://github.com/open-tool-forge/fpga-toolchain/issues/58#issuecomment-706820905, `ghdl --version` currently shows `GHDL 1.0-dev () [Dunoon edition]`. That is because the configure/Makefile depend on sources being in a git repo for building the "version description string". However, `git_clone` removes any reference to git, including `.git`.

Optionally, envvar `GHDL_DESC` can be used for providing a fallback description string. That's what I did here. Anyway, feel free to use some better content. 