### PR TITLE
scripts: Avoid holding up build process in git log

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -61,7 +61,7 @@ function git_clone {
     git -C $dir_name checkout $git_commit
     [[ ! -z "$update_submodules" ]] && git -C $dir_name submodule init
     [[ ! -z "$update_submodules" ]] && git -C $dir_name submodule update
-    git -C $dir_name log -1
+    git -C $dir_name --no-pager log -1
 
     # -- Copy the upstream sources into the build directory
     rsync -a $dir_name $BUILD_DIR --exclude .git


### PR DESCRIPTION
`git log`, when started from an interactive terminal, invokes the default pager (`less` by default). This tends to hold up the build process. I don't think this is intentional so pass the `--no-pager` flag. This doesn't affect non-interactive builds.