### PR TITLE
yosys: patch was upstreamed, GHDL_DIR is now GHDL_PREFIX

### DIFF
--- a/scripts/compile_yosys.sh
+++ b/scripts/compile_yosys.sh
@@ -30,7 +30,7 @@ then
     mkdir -p frontends/ghdl
     cp -R ../$dir_name_gyp/src/* frontends/ghdl
     MAKEFILE_CONF_GHDL=$'ENABLE_GHDL := 1\n'
-    MAKEFILE_CONF_GHDL+="GHDL_DIR := $PACKAGE_DIR/$NAME"
+    MAKEFILE_CONF_GHDL+="GHDL_PREFIX := $PACKAGE_DIR/$NAME"
 
     if [ $ARCH == "darwin" ]; then
         GHDL_LDLIBS="$PACKAGE_DIR/$NAME/lib/libghdl.a $(tr -s '\n' ' ' < $PACKAGE_DIR/$NAME/lib/libghdl.link)"

--- a/scripts/yosys_ghdl.diff
+++ b/scripts/yosys_ghdl.diff
@@ -2,32 +2,24 @@ diff --git a/Makefile b/Makefile
 index 45213c6f..f8393ea4 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -21,6 +21,7 @@ ENABLE_COVER := 1
- ENABLE_LIBYOSYS := 0
- ENABLE_PROTOBUF := 0
- ENABLE_ZLIB := 1
-+ENABLE_GHDL := 0
- 
- # python wrappers
- ENABLE_PYOSYS := 0
 @@ -82,7 +83,7 @@ all: top-all
  YOSYS_SRC := $(dir $(firstword $(MAKEFILE_LIST)))
  VPATH := $(YOSYS_SRC)
- 
+
 -CXXFLAGS := $(CXXFLAGS) -Wall -Wextra -ggdb -I. -I"$(YOSYS_SRC)" -MD -MP -D_YOSYS_ -fPIC -I$(PREFIX)/include
 +CXXFLAGS := $(CXXFLAGS) -w -I. -I"$(YOSYS_SRC)" -MD -MP -D_YOSYS_ -I$(PREFIX)/include
  LDLIBS := $(LDLIBS) -lstdc++ -lm
  PLUGIN_LDFLAGS :=
- 
+
 @@ -119,7 +120,7 @@ export PATH := $(PORT_PREFIX)/bin:$(PATH)
  endif
- 
+
  else
 -LDFLAGS += -rdynamic
 +LDFLAGS +=
  LDLIBS += -lrt
  endif
- 
+
 @@ -184,7 +185,7 @@ endif
  ifeq ($(CONFIG),clang)
  CXX = clang
@@ -35,20 +27,5 @@ index 45213c6f..f8393ea4 100644
 -CXXFLAGS += -std=c++11 -Os
 +CXXFLAGS += -std=c++11
  ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"
- 
+
  ifneq ($(SANITIZER),)
-@@ -510,6 +511,14 @@ endif
- endif
- endif
- 
-+ifeq ($(ENABLE_GHDL),1)
-+GHDL_DIR ?= /usr/local/ghdl
-+GHDL_INCLUDE_DIR ?= $(GHDL_DIR)/include
-+GHDL_LIB_DIR ?= $(GHDL_DIR)/lib
-+CXXFLAGS += -I$(GHDL_INCLUDE_DIR) -DYOSYS_ENABLE_GHDL
-+LDLIBS += $(GHDL_LIB_DIR)/libghdl.a $(shell cat $(GHDL_LIB_DIR)/ghdl.link)
-+endif
-+
- ifeq ($(ENABLE_VERIFIC),1)
- VERIFIC_DIR ?= /usr/local/src/verific_lib
- VERIFIC_COMPONENTS ?= verilog vhdl database util containers hier_tree


### PR DESCRIPTION
Hopefully, this fixes #69. At the same time, the now upstreamed parts of the patch are removed from `yosys_ghdl.diff`.